### PR TITLE
NER strided training samples & relax dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@ classifiers =
 packages =
     dragon_baseline
 install_requires =
-    torch==2.0.1
-    transformers==4.35.0
+    torch
+    transformers
     datasets
     evaluate
     accelerate

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
         long_description = fh.read()
 
     setuptools.setup(
-        version="0.2.4",
+        version="0.3.0",
         author_email="Joeran.Bosma@radboudumc.nl",
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
         long_description = fh.read()
 
     setuptools.setup(
-        version="0.2.3",
+        version="0.2.4",
         author_email="Joeran.Bosma@radboudumc.nl",
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/dragon_baseline/main.py
+++ b/src/dragon_baseline/main.py
@@ -199,6 +199,7 @@ class DragonBaseline(NLPAlgorithm):
         self.load_best_model_at_end = True
         self.metric_for_best_model = "loss"
         self.fp16 = False
+        self.create_strided_training_examples = False
 
         # paths for saving the preprocessed data and model checkpoints
         self.nlp_dataset_train_preprocessed_path = Path(workdir / "nlp-dataset-train-preprocessed.json")
@@ -461,6 +462,8 @@ class DragonBaseline(NLPAlgorithm):
             ])
         if self.fp16:
             cmd.append("--fp16")
+        if self.create_strided_training_examples:
+            cmd.append("--create_strided_training_examples")
 
         cmd = [str(arg) for arg in cmd]
         print("Training command:")

--- a/src/dragon_baseline/main.py
+++ b/src/dragon_baseline/main.py
@@ -448,8 +448,6 @@ class DragonBaseline(NLPAlgorithm):
             cmd.extend([
                 "--label_column_names", ",".join(label_names),
             ])
-            if self.create_strided_training_examples:
-                cmd.append("--create_strided_training_examples")
         else:
             cmd.extend([
                 "--label_column_name", self.task.target.label_name,
@@ -458,6 +456,9 @@ class DragonBaseline(NLPAlgorithm):
             cmd.extend([
                 "--text_column_delimiter", tokenizer.sep_token,
             ])
+
+            if self.create_strided_training_examples:
+                cmd.append("--create_strided_training_examples")
         if self.metric_for_best_model is not None:
             cmd.extend([
                 "--metric_for_best_model", str(self.metric_for_best_model),

--- a/src/dragon_baseline/main.py
+++ b/src/dragon_baseline/main.py
@@ -452,13 +452,13 @@ class DragonBaseline(NLPAlgorithm):
             cmd.extend([
                 "--label_column_name", self.task.target.label_name,
             ])
-        if not self.task.target.problem_type in [ProblemType.SINGLE_LABEL_NER, ProblemType.MULTI_LABEL_NER]:
+        if self.task.target.problem_type in [ProblemType.SINGLE_LABEL_NER, ProblemType.MULTI_LABEL_NER]:
+            if self.create_strided_training_examples:
+                cmd.append("--create_strided_training_examples")
+        else:
             cmd.extend([
                 "--text_column_delimiter", tokenizer.sep_token,
             ])
-
-            if self.create_strided_training_examples:
-                cmd.append("--create_strided_training_examples")
         if self.metric_for_best_model is not None:
             cmd.extend([
                 "--metric_for_best_model", str(self.metric_for_best_model),

--- a/src/dragon_baseline/main.py
+++ b/src/dragon_baseline/main.py
@@ -175,7 +175,7 @@ def balance_negative_samples(df: pd.DataFrame, label_name: str, seed: int) -> pd
 
 
 class DragonBaseline(NLPAlgorithm):
-    def __init__(self, input_path: Path = Path("/input"), output_path: Path = Path("/output"), workdir: Path = Path("/opt/app"), model_name: Union[str, Path] = "joeranbosma/dragon-roberta-large-domain-specific", **kwargs):
+    def __init__(self, input_path: Path = Path("/input"), output_path: Path = Path("/output"), workdir: Path = Path("/opt/app"), model_name: Union[str, Path] = "distilbert-base-multilingual-cased", **kwargs):
         """
         Baseline implementation for the DRAGON Challenge (https://dragon.grand-challenge.org/).
         This baseline uses the HuggingFace Transformers library (https://huggingface.co/transformers/).

--- a/src/dragon_baseline/main.py
+++ b/src/dragon_baseline/main.py
@@ -448,6 +448,8 @@ class DragonBaseline(NLPAlgorithm):
             cmd.extend([
                 "--label_column_names", ",".join(label_names),
             ])
+            if self.create_strided_training_examples:
+                cmd.append("--create_strided_training_examples")
         else:
             cmd.extend([
                 "--label_column_name", self.task.target.label_name,
@@ -462,8 +464,6 @@ class DragonBaseline(NLPAlgorithm):
             ])
         if self.fp16:
             cmd.append("--fp16")
-        if self.create_strided_training_examples:
-            cmd.append("--create_strided_training_examples")
 
         cmd = [str(arg) for arg in cmd]
         print("Training command:")


### PR DESCRIPTION
* Add the option to create multiple training examples from a single example by splitting the text into multiple segments with overlap, when a sample is longer than the maximum model sequence length.
* Relax the version of the torch and transformers dependencies for easier installation. The fully specified versions are still available in requirements.txt.