### PR TITLE
Allow str and Path arguments to be passed as path arguments to DragonBaseline class

### DIFF
--- a/src/dragon_baseline/main.py
+++ b/src/dragon_baseline/main.py
@@ -175,7 +175,7 @@ def balance_negative_samples(df: pd.DataFrame, label_name: str, seed: int) -> pd
 
 
 class DragonBaseline(NLPAlgorithm):
-    def __init__(self, input_path: Path = Path("/input"), output_path: Path = Path("/output"), workdir: Path = Path("/opt/app"), model_name: Union[str, Path] = "distilbert-base-multilingual-cased", **kwargs):
+    def __init__(self, input_path: Union[str, Path] = Path("/input"), output_path: Union[str, Path] = Path("/output"), workdir: Union[str, Path] = Path("/opt/app"), model_name: Union[str, Path] = "distilbert-base-multilingual-cased", **kwargs):
         """
         Baseline implementation for the DRAGON Challenge (https://dragon.grand-challenge.org/).
         This baseline uses the HuggingFace Transformers library (https://huggingface.co/transformers/).
@@ -202,10 +202,10 @@ class DragonBaseline(NLPAlgorithm):
         self.create_strided_training_examples = True
 
         # paths for saving the preprocessed data and model checkpoints
-        self.nlp_dataset_train_preprocessed_path = Path(workdir / "nlp-dataset-train-preprocessed.json")
-        self.nlp_dataset_val_preprocessed_path = Path(workdir / "nlp-dataset-val-preprocessed.json")
-        self.nlp_dataset_test_preprocessed_path = Path(workdir / "nlp-dataset-test-preprocessed.json")
-        self.model_save_dir = Path(workdir / "checkpoints")
+        self.nlp_dataset_train_preprocessed_path = Path(workdir) / "nlp-dataset-train-preprocessed.json"
+        self.nlp_dataset_val_preprocessed_path = Path(workdir) / "nlp-dataset-val-preprocessed.json"
+        self.nlp_dataset_test_preprocessed_path = Path(workdir) / "nlp-dataset-test-preprocessed.json"
+        self.model_save_dir = Path(workdir) / "checkpoints"
 
         # keep track of the common prefix of the reports, to remove it
         self.common_prefix = None

--- a/src/dragon_baseline/nlp_algorithm.py
+++ b/src/dragon_baseline/nlp_algorithm.py
@@ -177,11 +177,11 @@ class NLPAlgorithm(ClassificationAlgorithm):
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
         # paths
-        self.dataset_train_path = self._input_path / "nlp-training-dataset.json"
-        self.dataset_val_path = self._input_path / "nlp-validation-dataset.json"
-        self.dataset_test_path = self._input_path / "nlp-test-dataset.json"
-        self.task_details_path = self._input_path / "nlp-task-configuration.json"
-        self.test_predictions_path = self._output_path / "nlp-predictions-dataset.json"
+        self.dataset_train_path = Path(self._input_path) / "nlp-training-dataset.json"
+        self.dataset_val_path = Path(self._input_path) / "nlp-validation-dataset.json"
+        self.dataset_test_path = Path(self._input_path) / "nlp-test-dataset.json"
+        self.task_details_path = Path(self._input_path) / "nlp-task-configuration.json"
+        self.test_predictions_path = Path(self._output_path) / "nlp-predictions-dataset.json"
 
     def process(self):
         self.load()

--- a/src/dragon_baseline/nlp_algorithm.py
+++ b/src/dragon_baseline/nlp_algorithm.py
@@ -174,7 +174,12 @@ class NLPAlgorithm(ClassificationAlgorithm):
         self.df_test: pd.DataFrame = None  # loaded in self.load()
         self.task: TaskDetails = None  # loaded in self.load()
         self.label_scalers: Dict[str, TransformerMixin] = {}  # set in self.scale_labels()
-        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda:0")
+        elif torch.mps.is_available():
+            self.device = torch.device("mps:0")
+        else:
+            self.device = torch.device("cpu")
 
         # paths
         self.dataset_train_path = Path(self._input_path) / "nlp-training-dataset.json"


### PR DESCRIPTION
If paths are passed as strings in the previous implementation an unsupported operand error will be thrown for trying to concatenate str and str using "/".  